### PR TITLE
Add scrollbar corner background color

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ postcss()
 .scrollable::-webkit-scrollbar-track {
   background-color: green;
 }
+.test::-webkit-scrollbar-corner {
+  background-color: green;
+}
 .scrollable::-webkit-scrollbar {
   width: 0.5rem;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -103,12 +103,14 @@ export default postcss.plugin(name, (options = defaults) => (css, result) => {
           return {
             ...acc,
             track: colorMap[curr.value] || curr.value,
+            corner: colorMap[curr.value] || curr.value,
           };
         }
 
         return {
           thumb: colorMap[curr.value] || curr.value,
           track: colorMap[curr.value] || curr.value,
+          corner: colorMap[curr.value] || curr.value,
         };
       }, {});
 

--- a/test/__snapshots__/color.spec.js.snap
+++ b/test/__snapshots__/color.spec.js.snap
@@ -7,6 +7,9 @@ exports[`color:  <color> <color> 1`] = `
 .test::-webkit-scrollbar-track {
   background-color: green;
 }
+.test::-webkit-scrollbar-corner {
+  background-color: green;
+}
 .test {
   scrollbar-color: rebeccapurple green;
 }"
@@ -23,6 +26,9 @@ exports[`color:  keyword 1`] = `
   background-color: initial;
 }
 .test::-webkit-scrollbar-track {
+  background-color: initial;
+}
+.test::-webkit-scrollbar-corner {
   background-color: initial;
 }
 .test {


### PR DESCRIPTION
This will add the corresponding `scrollbar-color` to `::-webkit-scrollbar-corner`, so it's not white and matches Firefox, which has the corner the same color as the track.

### Before
![before](https://user-images.githubusercontent.com/9970403/51732067-e476fb80-2031-11e9-99c3-2e4abce32c52.png)

### After
![after](https://user-images.githubusercontent.com/9970403/51732088-f5277180-2031-11e9-9a32-0ca306511f0a.png)
