### PR TITLE
Match horizontal scrollbar width to vertical scrollbar width

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ postcss()
 }
 .scrollable::-webkit-scrollbar {
   width: 0.5rem;
+  height: 0.5rem;
 }
 .scrollable {
   -ms-overflow-style: auto;
@@ -78,6 +79,7 @@ postcss()
 /* output */
 .scrollable::-webkit-scrollbar {
   width: 0;
+  height: 0;
 }
 .scrollable {
   -ms-overflow-style: none;

--- a/src/index.js
+++ b/src/index.js
@@ -59,12 +59,20 @@ export default postcss.plugin(name, (options = defaults) => (css, result) => {
       .rule({
         selector: processor.processSync(parent.selector),
       })
-      .append(
-        postcss.decl({
-          prop: 'width',
-          value: widthMap[keyword],
-        })
-      );
+
+    newRule.append(
+      postcss.decl({
+        prop: 'width',
+        value: widthMap[keyword],
+      })
+    );
+
+    newRule.append(
+      postcss.decl({
+        prop: 'height',
+        value: widthMap[keyword],
+      })
+    );
 
     root.insertBefore(parent, newRule);
 

--- a/test/__snapshots__/control.spec.js.snap
+++ b/test/__snapshots__/control.spec.js.snap
@@ -3,6 +3,7 @@
 exports[`control:  PostCSS API 1`] = `
 ".test::-webkit-scrollbar {
   width: 0.5rem;
+  height: 0.5rem;
 }
 .test {
   -ms-overflow-style: auto;
@@ -13,6 +14,7 @@ exports[`control:  PostCSS API 1`] = `
 exports[`control:  PostCSS legacy API 1`] = `
 ".test::-webkit-scrollbar {
   width: 0.5rem;
+  height: 0.5rem;
 }
 .test {
   -ms-overflow-style: auto;
@@ -23,6 +25,7 @@ exports[`control:  PostCSS legacy API 1`] = `
 exports[`control:  no options 1`] = `
 ".test::-webkit-scrollbar {
   width: 0.5rem;
+  height: 0.5rem;
 }
 .test {
   -ms-overflow-style: auto;
@@ -33,6 +36,7 @@ exports[`control:  no options 1`] = `
 exports[`control:  with options 1`] = `
 ".test::-webkit-scrollbar {
   width: 0.5rem;
+  height: 0.5rem;
 }
 .test {
   -ms-overflow-style: auto;

--- a/test/__snapshots__/options.spec.js.snap
+++ b/test/__snapshots__/options.spec.js.snap
@@ -3,6 +3,7 @@
 exports[`options:  default options 1`] = `
 ".test::-webkit-scrollbar {
   width: initial;
+  height: initial;
 }
 .test {
   -ms-overflow-style: auto;
@@ -13,6 +14,7 @@ exports[`options:  default options 1`] = `
 exports[`options:  with options 1`] = `
 ".test::-webkit-scrollbar {
   width: 0;
+  height: 0;
 }
 .test {
   -ms-overflow-style: -ms-autohiding-scrollbar;

--- a/test/__snapshots__/width.spec.js.snap
+++ b/test/__snapshots__/width.spec.js.snap
@@ -3,6 +3,7 @@
 exports[`width:  auto keyword 1`] = `
 ".test::-webkit-scrollbar {
   width: initial;
+  height: initial;
 }
 .test {
   -ms-overflow-style: auto;
@@ -19,6 +20,7 @@ exports[`width:  erroneous keyword 1`] = `
 exports[`width:  none keyword 1`] = `
 ".test::-webkit-scrollbar {
   width: 0;
+  height: 0;
 }
 .test {
   -ms-overflow-style: none;
@@ -29,6 +31,7 @@ exports[`width:  none keyword 1`] = `
 exports[`width:  thin keyword 1`] = `
 ".test::-webkit-scrollbar {
   width: 0.5rem;
+  height: 0.5rem;
 }
 .test {
   -ms-overflow-style: auto;


### PR DESCRIPTION
This will match the widths of the horizontal and vertical scrollbars as `::-webkit-scrollbar` uses `height` to set the width of the horizontal scrollbar


### Before
![before](https://user-images.githubusercontent.com/9970403/51733106-28b7cb00-2035-11e9-80cf-29da2785d72e.png)

### After
![after](https://user-images.githubusercontent.com/9970403/51733118-30776f80-2035-11e9-898f-80ccd5fa577a.png)

